### PR TITLE
fix: [file-dialog] Repeatedly shows and close file selection dialog p…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+gtk+3.0 (3.24.41-1deepin3) unstable; urgency=medium
+
+  * fix multiple open and close file dialog, app crash.
+  * debian/patchs:
+    - Add file Fix-show-and-close-filedialog-crash.patch.
+  * debian/pathchs/series:
+    - Add file record in the series.
+
+ -- gongheng <gongheng@uniontech.com>  Tue, 15 Oct 2024 17:10:25 +0800
+
 gtk+3.0 (3.24.41-1deepin2) unstable; urgency=medium
 
   * fix CVE-2024-6655.

--- a/debian/patches/Fix-show-and-close-filediaog-crash.patch
+++ b/debian/patches/Fix-show-and-close-filediaog-crash.patch
@@ -1,0 +1,37 @@
+Index: gtkplus3.0/gtk/ddefiledialog.c
+===================================================================
+--- gtkplus3.0.orig/gtk/ddefiledialog.c
++++ gtkplus3.0/gtk/ddefiledialog.c
+@@ -459,7 +459,7 @@ static void _gtk_file_chooser_set_do_ove
+     d_debug("value: %d\n", do_overwrite_confirmation);
+ }
+ 
+-static void d_show_dbus_filedialog(GtkWidget *widget_ghost)
++static gboolean on_show_timeout(GtkWidget *widget_ghost)
+ {
+     guint64 dbus_dialog_winId;
+     const gchar *title = gtk_window_get_title(GTK_WINDOW(widget_ghost));
+@@ -483,15 +483,21 @@ static void d_show_dbus_filedialog(GtkWi
+     }
+ 
+     if (!d_dbus_filedialog_call_by_ghost_widget_sync(widget_ghost, "show", NULL, NULL, NULL))
+-        return;
++        return FALSE;
+ 
+     
+     if (GDK_IS_X11_DISPLAY(gtk_widget_get_display(widget_ghost))) {
+         if (!d_dbus_filedialog_call_by_ghost_widget_sync(widget_ghost, "winId", NULL, "(t)", &dbus_dialog_winId))
+-            return;
++            return FALSE;
+         XSetTransientForHint(gdk_x11_get_default_xdisplay(), dbus_dialog_winId, GDK_WINDOW_XID(gtk_widget_get_window(widget_ghost)));
+     }
+     
++    return FALSE;
++}
++
++static void d_show_dbus_filedialog(GtkWidget *widget_ghost)
++{
++    g_timeout_add(200, on_show_timeout, widget_ghost);
+ }
+ 
+ static void d_hide_dbus_filedialog(GtkWidget *widget_ghost)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -6,3 +6,4 @@ reftests-Allow-minor-differences-to-be-tolerated.patch
 dde-filedialog.patch
 fix-filedialog-in-wayland.patch
 CVE-2024-6655.patch
+Fix-show-and-close-filediaog-crash.patch


### PR DESCRIPTION
…rogram crash

1. Timing problem: the uos window is show after gtk window show and enter the event loop.
2. Delay the display of the uos window. After the gtk window is displayed, the event loop is entered and the uos window is displayed.

Log: fix issue
Task: https://pms.uniontech.com/task-view-361893.html